### PR TITLE
Install build essentials

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update
 RUN apt-get install -y ruby2.3 
 RUN apt-get install -y ruby2.3-dev
 RUN gem install bundler
+RUN apt-get install build-essential
 
 WORKDIR /workspace
 


### PR DESCRIPTION
One last PR. Bundle command needed some build tools that didn't exist on the Ubuntu distro.
