### PR TITLE
Add pipeline deployment.json file.

### DIFF
--- a/deployment.json
+++ b/deployment.json
@@ -1,0 +1,28 @@
+{
+  "agent": {
+    "os": "linux",
+    "docker": true
+  },
+  "steps": [
+    {
+      "name": "docker_build",
+      "image": "android"
+    },
+    {
+      "name": "docker_tag",
+      "image": "android",
+      "force": true,
+      "oldTag": "latest",
+      "newTag": "${BUILDKITE_BRANCH}-${BUILDKITE_BUILD_NUMBER}"
+    },
+    {
+      "name": "docker_push",
+      "image": "android"
+    },
+    {
+      "name": "docker_push",
+      "image": "android",
+      "tag": "${BUILDKITE_BRANCH}-${BUILDKITE_BUILD_NUMBER}"
+    }
+  ]
+}


### PR DESCRIPTION
Add deployment.json file to build image internally rather than on hub.docker.com. Images are tagged with branch and build number so we can reference exact images which will allow removing unused packages immediately.
